### PR TITLE
Add support for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     "require": {
         "php": ">=5.6.4",
         "guzzlehttp/guzzle": "~6.0",
-        "illuminate/notifications": "5.3.*|5.4.*",
-        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*"
+        "illuminate/notifications": "5.3.*|5.4.*|5.5.*",
+        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "4.*",
-        "orchestra/testbench": "3.3.x-dev",
-        "orchestra/database": "3.3.x-dev"
+        "phpunit/phpunit": "4.*|~6.0",
+        "orchestra/testbench": "3.3.x-dev|^3.5.0",
+        "orchestra/database": "3.3.x-dev|^3.5.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -2,14 +2,13 @@
 
 namespace NotificationChannels\Webhook\Test;
 
+use Mockery;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
+use Orchestra\Testbench\TestCase;
 use Illuminate\Notifications\Notification;
-use Mockery;
-use NotificationChannels\Webhook\Exceptions\CouldNotSendNotification;
 use NotificationChannels\Webhook\WebhookChannel;
 use NotificationChannels\Webhook\WebhookMessage;
-use Orchestra\Testbench\TestCase;
 
 class ChannelTest extends TestCase
 {
@@ -33,6 +32,7 @@ class ChannelTest extends TestCase
         $channel = new WebhookChannel($client);
         $channel->send(new TestNotifiable(), new TestNotification());
     }
+
     /** @test */
     public function it_can_send_a_notification_with_2xx_status()
     {
@@ -54,11 +54,12 @@ class ChannelTest extends TestCase
         $channel->send(new TestNotifiable(), new TestNotification());
     }
 
-    /** @test */
+    /**
+     * @expectedException NotificationChannels\Webhook\Exceptions\CouldNotSendNotification
+     * @test
+     */
     public function it_throws_an_exception_when_it_could_not_send_the_notification()
     {
-        $this->setExpectedException(CouldNotSendNotification::class);
-
         $response = new Response(500);
         $client = Mockery::mock(Client::class);
         $client->shouldReceive('post')
@@ -81,7 +82,6 @@ class TestNotifiable
         return 'https://notifiable-webhook-url.com';
     }
 }
-
 
 class TestNotification extends Notification
 {

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -3,9 +3,10 @@
 namespace NotificationChannels\Webhook\Test;
 
 use Illuminate\Support\Arr;
+use Orchestra\Testbench\TestCase;
 use NotificationChannels\Webhook\WebhookMessage;
 
-class MessageTest extends \PHPUnit_Framework_TestCase
+class MessageTest extends TestCase
 {
     /** @var \NotificationChannels\Webhook\WebhookMessage */
     protected $message;


### PR DESCRIPTION
fixes #10 

The changes made to ChannelTest and MessageTest work on PHPUnit 4.x as well as 6.0. To test this, I stashed my changes to `composer.json` and ran `$ composer update` + `$ phpunit`.

Here is the updated `$ phpunit` output for this PR:

```
PHPUnit 6.3.0 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.5
Configuration: laravel-webhook-notifications/phpunit.xml.dist
Error:         No code coverage driver is available

RR......                                                            8 / 8 (100%)

Time: 209 ms, Memory: 10.00MB

There were 2 risky tests:

1) NotificationChannels\Webhook\Test\ChannelTest::it_can_send_a_notification
This test did not perform any assertions

2) NotificationChannels\Webhook\Test\ChannelTest::it_can_send_a_notification_with_2xx_status
This test did not perform any assertions

OK, but incomplete, skipped, or risky tests!
Tests: 8, Assertions: 6, Risky: 2.
```