### PR TITLE
Update WebhookChannel to use the json request option in Guzzle

### DIFF
--- a/src/WebhookChannel.php
+++ b/src/WebhookChannel.php
@@ -37,7 +37,7 @@ class WebhookChannel
         $webhookData = $notification->toWebhook($notifiable)->toArray();
 
         $response = $this->client->post($url, [
-            'body' => json_encode(Arr::get($webhookData, 'data')),
+            'json' => Arr::get($webhookData, 'data'),
             'verify' => false,
             'headers' => Arr::get($webhookData, 'headers'),
         ]);

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -22,7 +22,7 @@ class ChannelTest extends TestCase
             ->once()
             ->with('https://notifiable-webhook-url.com',
                 [
-                    'body' => '{"payload":{"webhook":"data"}}',
+                    'json' => ['payload' => ['webhook' => 'data']],
                     'verify' => false,
                     'headers' => [
                         'User-Agent' => 'WebhookAgent',
@@ -42,7 +42,7 @@ class ChannelTest extends TestCase
             ->once()
             ->with('https://notifiable-webhook-url.com',
                 [
-                    'body' => '{"payload":{"webhook":"data"}}',
+                    'json' => ['payload' => ['webhook' => 'data']],
                     'verify' => false,
                     'headers' => [
                         'User-Agent' => 'WebhookAgent',


### PR DESCRIPTION
The `json` option essentially does what the code is doing now (calling `json_encode`) along with setting the `Content-Type` header to `application/json`.

---

This will automatically set the appropriate Content-Type header[1]

[1] http://docs.guzzlephp.org/en/stable/request-options.html#json