### PR TITLE
Add query and verify option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ public function routeNotificationForWebhook()
 ### Available methods
 
 - `data('')`: Accepts a JSON-encodable value for the Webhook body.
+- `query('')`: Accepts an associative array of query string values to add to the request.
 - `userAgent('')`: Accepts a string value for the Webhook user agent.
 - `header($name, $value)`: Sets additional headers to send with the POST Webhook.
+- `verify()`: Enable the SSL certificate verification or provide the path to a CA bundle
 
 
 ## Changelog

--- a/src/WebhookChannel.php
+++ b/src/WebhookChannel.php
@@ -37,8 +37,9 @@ class WebhookChannel
         $webhookData = $notification->toWebhook($notifiable)->toArray();
 
         $response = $this->client->post($url, [
+            'query' => Arr::get($webhookData, 'query'),
             'body' => json_encode(Arr::get($webhookData, 'data')),
-            'verify' => false,
+            'verify' => Arr::get($webhookData, 'verify'),
             'headers' => Arr::get($webhookData, 'headers'),
         ]);
 

--- a/src/WebhookChannel.php
+++ b/src/WebhookChannel.php
@@ -4,8 +4,8 @@ namespace NotificationChannels\Webhook;
 
 use GuzzleHttp\Client;
 use Illuminate\Support\Arr;
-use NotificationChannels\Webhook\Exceptions\CouldNotSendNotification;
 use Illuminate\Notifications\Notification;
+use NotificationChannels\Webhook\Exceptions\CouldNotSendNotification;
 
 class WebhookChannel
 {

--- a/src/WebhookMessage.php
+++ b/src/WebhookMessage.php
@@ -5,6 +5,13 @@ namespace NotificationChannels\Webhook;
 class WebhookMessage
 {
     /**
+     * The GET parameters of the request.
+     *
+     * @var array|string|null
+     */
+    protected $query;
+
+    /**
      * The POST data of the Webhook request.
      *
      * @var mixed
@@ -26,6 +33,13 @@ class WebhookMessage
     protected $userAgent;
 
     /**
+     * The Guzzle verify option.
+     *
+     * @var bool|string
+     */
+    protected $verify = false;
+
+    /**
      * @param mixed $data
      *
      * @return static
@@ -41,6 +55,20 @@ class WebhookMessage
     public function __construct($data = '')
     {
         $this->data = $data;
+    }
+
+    /**
+     * Set the Webhook parameters to be URL encoded.
+     *
+     * @param mixed $query
+     *
+     * @return $this
+     */
+    public function query($query)
+    {
+        $this->query = $query;
+
+        return $this;
     }
 
     /**
@@ -87,13 +115,27 @@ class WebhookMessage
     }
 
     /**
+     * Indicate that the request should be verified.
+     *
+     * @return $this
+     */
+    public function verify($value = true)
+    {
+        $this->verify = $value;
+
+        return $this;
+    }
+
+    /**
      * @return array
      */
     public function toArray()
     {
         return [
+            'query' => $this->query,
             'data' => $this->data,
             'headers' => $this->headers,
+            'verify' => $this->verify,
         ];
     }
 }

--- a/src/WebhookMessage.php
+++ b/src/WebhookMessage.php
@@ -4,13 +4,25 @@ namespace NotificationChannels\Webhook;
 
 class WebhookMessage
 {
-    /** @var mixed */
+    /**
+     * The POST data of the Webhook request.
+     *
+     * @var mixed
+     */
     protected $data;
 
-    /** @var array|null */
+    /**
+     * The headers to send with the request.
+     *
+     * @var array|null
+     */
     protected $headers;
 
-    /** @var string|null */
+    /**
+     * The user agent header.
+     *
+     * @var string|null
+     */
     protected $userAgent;
 
     /**

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -21,6 +21,7 @@ class ChannelTest extends TestCase
             ->once()
             ->with('https://notifiable-webhook-url.com',
                 [
+                    'query' => null,
                     'body' => '{"payload":{"webhook":"data"}}',
                     'verify' => false,
                     'headers' => [
@@ -42,6 +43,7 @@ class ChannelTest extends TestCase
             ->once()
             ->with('https://notifiable-webhook-url.com',
                 [
+                    'query' => null,
                     'body' => '{"payload":{"webhook":"data"}}',
                     'verify' => false,
                     'headers' => [
@@ -52,6 +54,31 @@ class ChannelTest extends TestCase
             ->andReturn($response);
         $channel = new WebhookChannel($client);
         $channel->send(new TestNotifiable(), new TestNotification());
+    }
+
+    /** @test */
+    public function it_can_send_a_notification_with_query_string()
+    {
+        $response = new Response();
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('post')
+            ->once()
+            ->with('https://notifiable-webhook-url.com',
+                [
+                    'query' => [
+                        'webhook' => 'data',
+                    ],
+                    'body' => '""',
+                    'verify' => false,
+                    'headers' => [
+                        'User-Agent' => 'WebhookAgent',
+                        'X-Custom' => 'CustomHeader',
+                    ],
+                ])
+            ->andReturn($response);
+
+        $channel = new WebhookChannel($client);
+        $channel->send(new TestNotifiable(), new QueryTestNotification ());
     }
 
     /**
@@ -96,5 +123,17 @@ class TestNotification extends Notification
                 ]
             ))->userAgent('WebhookAgent')
             ->header('X-Custom', 'CustomHeader');
+    }
+}
+
+class QueryTestNotification  extends Notification
+{
+    public function toWebhook($notifiable)
+    {
+        return
+            (new WebhookMessage())
+                ->query(['webhook' => 'data'])
+                ->userAgent('WebhookAgent')
+                ->header('X-Custom', 'CustomHeader');
     }
 }

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -78,7 +78,7 @@ class ChannelTest extends TestCase
             ->andReturn($response);
 
         $channel = new WebhookChannel($client);
-        $channel->send(new TestNotifiable(), new QueryTestNotification ());
+        $channel->send(new TestNotifiable(), new QueryTestNotification());
     }
 
     /**
@@ -126,7 +126,7 @@ class TestNotification extends Notification
     }
 }
 
-class QueryTestNotification  extends Notification
+class QueryTestNotification extends Notification
 {
     public function toWebhook($notifiable)
     {

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -34,6 +34,13 @@ class MessageTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_the_webhook_query()
+    {
+        $this->message->query(['foo' => 'bar']);
+        $this->assertEquals(['foo' => 'bar'], Arr::get($this->message->toArray(), 'query'));
+    }
+
+    /** @test */
     public function it_can_set_the_webhook_data()
     {
         $this->message->data(['foo' => 'bar']);
@@ -52,5 +59,12 @@ class MessageTest extends TestCase
     {
         $this->message->header('X-Custom', 'Value');
         $this->assertEquals(['X-Custom' => 'Value'], Arr::get($this->message->toArray(), 'headers'));
+    }
+
+    /** @test */
+    public function it_can_verify_the_request()
+    {
+        $this->message->verify();
+        $this->assertEquals(true, Arr::get($this->message->toArray(), 'verify'));
     }
 }


### PR DESCRIPTION
Here are a couple of changes that may be useful to some:

- Added the possibility to set the GET parameters with [`query()`](http://docs.guzzlephp.org/en/stable/request-options.html#query), in order to integrate endpoints relying solely on the query string (e.g. sending a message via the [Zulip API](https://zulipchat.com/api/endpoints/)).

- Also added `verify()` as requested in #12.