### PR TITLE
chore: support newer laravel versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
+  - 7.2
+  - 7.3
 
 env:
   matrix:
@@ -15,7 +14,7 @@ before_script:
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:
-  - phpunit --coverage-text --coverage-clover=coverage.clover
+  - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Webhook notifications channel for Laravel 5.3
+# Webhook notifications channel for Laravel 5.5+ and 6.0
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/webhook.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/webhook)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
@@ -9,7 +9,7 @@
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/webhook/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/webhook/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/webhook.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/webhook)
 
-This package makes it easy to send webhooks using the Laravel 5.3 notification system.
+This package makes it easy to send webhooks using the Laravel notification system.
 
 ## Contents
 

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
+        "php": ">=7.0",
         "guzzlehttp/guzzle": "~6.0",
-        "illuminate/notifications": "5.3.*|5.4.*|5.5.*|5.6.*",
-        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*"
+        "illuminate/notifications": "~5.5 || ~6.0",
+        "illuminate/support": "~5.5 || ~6.0"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "4.*|~6.0",
-        "orchestra/testbench": "3.3.x-dev|^3.5.0",
-        "orchestra/database": "3.3.x-dev|^3.5.0"
+        "phpunit/phpunit": "~7.0 || ~8.0",
+        "orchestra/testbench": "^3.5.0 || ^4.0",
+        "orchestra/database": "^3.5.0 || ^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>


### PR DESCRIPTION
- Drop php < 7 support
- Allow laravel 5.7, 5.8, 6.0

Closes #20 