### PR TITLE
Laravel 8 support + PHP7.4 version testing addition in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.2
   - 7.3
   - 7.4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.2
   - 7.3
   - 7.4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
 
 env:
   matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to `webhook` will be documented in this file
 ## 2.1.0 - 2020-08-21
 
 * Added Laravel 8 support.
+* Dropped Laravel 6 support.
+* Dropped PHP7.2 support.
 * Added PHP7.4 version testing in Travis CI.
 
 ## 1.0.0 - 201X-XX-XX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `webhook` will be documented in this file
 
+## 2.1.0 - 2020-08-21
+
+* Added Laravel 8 support.
+* Added PHP7.4 version testing in Travis CI.
+
 ## 1.0.0 - 201X-XX-XX
 
-- initial release
+* initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable changes to `webhook` will be documented in this file
 
 * Added Laravel 8 support.
 * Dropped Laravel 6 support.
-* Dropped PHP7.2 support.
 * Added PHP7.4 version testing in Travis CI.
 
 ## 1.0.0 - 201X-XX-XX

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
     "require": {
         "php": "^7.2.5",
         "guzzlehttp/guzzle": "~7.0",
-        "illuminate/notifications": "~7.0 || ^8.0",
-        "illuminate/support": "~7.0 || ^8.0"
+        "illuminate/notifications": "^7.0||^8.0",
+        "illuminate/support": "^7.0||^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3",
         "phpunit/phpunit": "^9.0",
-        "orchestra/testbench": "^5.0 || ^6.0",
-        "orchestra/database": "^5.0 || ^6.0"
+        "orchestra/testbench": "^5.0||^6.0",
+        "orchestra/database": "^5.0||^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "guzzlehttp/guzzle": "~7.0",
+        "guzzlehttp/guzzle": "^7.0",
         "illuminate/notifications": "^7.0||^8.0",
         "illuminate/support": "^7.0||^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.2.5",
         "guzzlehttp/guzzle": "~7.0",
-        "illuminate/notifications": "~6.0 || ~7.0 || ^8.0",
-        "illuminate/support": "~6.0 || ~7.0 || ^8.0"
+        "illuminate/notifications": "~7.0 || ^8.0",
+        "illuminate/support": "~7.0 || ^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3",
         "phpunit/phpunit": "^9.0",
-        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0",
-        "orchestra/database": "^4.0 | ^5.0 || ^6.0"
+        "orchestra/testbench": "^5.0 || ^6.0",
+        "orchestra/database": "^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
-        "guzzlehttp/guzzle": "~6.0",
-        "illuminate/notifications": "~5.5 || ~6.0 || ~7.0 || ^8.0",
-        "illuminate/support": "~5.5 || ~6.0 || ~7.0 || ^8.0"
+        "php": "^7.3",
+        "guzzlehttp/guzzle": "~7.0",
+        "illuminate/notifications": "~6.0 || ~7.0 || ^8.0",
+        "illuminate/support": "~6.0 || ~7.0 || ^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3",
-        "phpunit/phpunit": "^8.0",
-        "orchestra/testbench": "^3.8.0 || ^4.0 || ^5.0 || ^6.0",
-        "orchestra/database": "^3.8.0 || ^4.0 | ^5.0 || ^6.0"
+        "phpunit/phpunit": "^9.0",
+        "orchestra/testbench": "^4.0 || ^5.0 || ^6.0",
+        "orchestra/database": "^4.0 | ^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
+        "php": "^7.2.5",
         "guzzlehttp/guzzle": "~6.0",
-        "illuminate/notifications": "~5.5 || ~6.0 || ~7.0",
-        "illuminate/support": "~5.5 || ~6.0 || ~7.0"
+        "illuminate/notifications": "~5.5 || ~6.0 || ~7.0 || ^8.0",
+        "illuminate/support": "~5.5 || ~6.0 || ~7.0 || ^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3",
         "phpunit/phpunit": "^8.0",
-        "orchestra/testbench": "^3.8.0 || ^4.0 || ^5.0",
-        "orchestra/database": "^3.8.0 || ^4.0 | ^5.0"
+        "orchestra/testbench": "^3.8.0 || ^4.0 || ^5.0 || ^6.0",
+        "orchestra/database": "^3.8.0 || ^4.0 | ^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
* Added Laravel 8 support.
* Added PHP7.4 version testing in Travis CI.