### PR TITLE
Add an event after the notification is sent

### DIFF
--- a/src/Events/WebhookNotificationSentEvent.php
+++ b/src/Events/WebhookNotificationSentEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace NotificationChannels\Webhook\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class WebhookNotificationSentEvent
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public $response;
+
+    public function __construct(array $response)
+    {
+        $this->response = $response;
+    }
+}

--- a/src/WebhookChannel.php
+++ b/src/WebhookChannel.php
@@ -5,6 +5,7 @@ namespace NotificationChannels\Webhook;
 use GuzzleHttp\Client;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Arr;
+use NotificationChannels\Webhook\Events\WebhookNotificationSentEvent;
 use NotificationChannels\Webhook\Exceptions\CouldNotSendNotification;
 
 class WebhookChannel
@@ -44,6 +45,8 @@ class WebhookChannel
             'verify' => Arr::get($webhookData, 'verify'),
             'headers' => Arr::get($webhookData, 'headers'),
         ]);
+
+        WebhookNotificationSentEvent::dispatch($response);
 
         if ($response->getStatusCode() >= 300 || $response->getStatusCode() < 200) {
             throw CouldNotSendNotification::serviceRespondedWithAnError($response);


### PR DESCRIPTION
Good morning in the morning.

Thank you for this awesome package it really helps me to achieve my goals in a very "Laravel-ey" way and I love it so much. 

I have a use case that I think others will run into as well. That is that I need to save the response from the provider into another table in my database. 

EG:

```
Send Webhook to provider -> provider returns a 500 error -> save this error to my tracking table -> resend this notification when provider sorts their life out. 
```

To achieve this I added a simple Event that gets dispatched with the response. I can then register a listener and ensure the notifications do not get lost in 5xx land 

:) 

Thank you for your review, happy to change class names and update accordingly