### PR TITLE
feat: Add http request options

### DIFF
--- a/src/WebhookChannel.php
+++ b/src/WebhookChannel.php
@@ -38,12 +38,15 @@ class WebhookChannel
 
         $webhookData = $notification->toWebhook($notifiable)->toArray();
 
-        $response = $this->client->post($url, [
-            'query' => Arr::get($webhookData, 'query'),
-            'body' => json_encode(Arr::get($webhookData, 'data')),
-            'verify' => Arr::get($webhookData, 'verify'),
-            'headers' => Arr::get($webhookData, 'headers'),
-        ]);
+        $response = $this->client->post($url, array_merge(
+            [
+                'query' => Arr::get($webhookData, 'query'),
+                'body' => json_encode(Arr::get($webhookData, 'data')),
+                'verify' => Arr::get($webhookData, 'verify'),
+                'headers' => Arr::get($webhookData, 'headers'),
+            ],
+            Arr::get($webhookData, 'http')
+        ));
 
         if ($response->getStatusCode() >= 300 || $response->getStatusCode() < 200) {
             throw CouldNotSendNotification::serviceRespondedWithAnError($response);

--- a/src/WebhookMessage.php
+++ b/src/WebhookMessage.php
@@ -39,6 +39,14 @@ class WebhookMessage
      */
     protected $verify = false;
 
+
+    /**
+     * Additional request options for the Guzzle HTTP client.
+     *
+     * @var array
+     */
+    protected $http = [];
+
     /**
      * @param mixed $data
      *
@@ -127,6 +135,19 @@ class WebhookMessage
     }
 
     /**
+     * Set additional request options for the Guzzle HTTP client.
+     *
+     * @param  array  $options
+     * @return $this
+     */
+    public function http(array $options)
+    {
+        $this->http = $options;
+
+        return $this;
+    }
+
+    /**
      * @return array
      */
     public function toArray()
@@ -136,6 +157,7 @@ class WebhookMessage
             'data' => $this->data,
             'headers' => $this->headers,
             'verify' => $this->verify,
+            'http' => $this->http,
         ];
     }
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -67,4 +67,11 @@ class MessageTest extends TestCase
         $this->message->verify();
         $this->assertEquals(true, Arr::get($this->message->toArray(), 'verify'));
     }
+
+    /** @test */
+    public function it_can_add_request_options()
+    {
+        $this->message->http(['timeout' => 3.14]);
+        $this->assertEquals(3.14, Arr::get($this->message->toArray(), 'http.timeout'));
+    }
 }


### PR DESCRIPTION
Added `http()` to allow setting HTTP options such as timeout value as requested in #46.