### PR TITLE
Implement `method` function in `WebhookMessage` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ public function routeNotificationForWebhook()
 - `userAgent('')`: Accepts a string value for the Webhook user agent.
 - `header($name, $value)`: Sets additional headers to send with the POST Webhook.
 - `verify()`: Enable the SSL certificate verification or provide the path to a CA bundle
+- `method('')`: Set the HTTP method to use for the Webhook request. Defaults to `POST`.
 
 ## Changelog
 

--- a/src/WebhookChannel.php
+++ b/src/WebhookChannel.php
@@ -13,7 +13,7 @@ class WebhookChannel
     protected $client;
 
     /**
-     * @param Client $client
+     * @param  Client  $client
      */
     public function __construct(Client $client)
     {
@@ -23,8 +23,8 @@ class WebhookChannel
     /**
      * Send the given notification.
      *
-     * @param mixed $notifiable
-     * @param \Illuminate\Notifications\Notification $notification
+     * @param  mixed  $notifiable
+     * @param  \Illuminate\Notifications\Notification  $notification
      *
      * @return \GuzzleHttp\Psr7\Response
      *

--- a/src/WebhookChannel.php
+++ b/src/WebhookChannel.php
@@ -25,7 +25,6 @@ class WebhookChannel
      *
      * @param  mixed  $notifiable
      * @param  \Illuminate\Notifications\Notification  $notification
-     *
      * @return \GuzzleHttp\Psr7\Response
      *
      * @throws \NotificationChannels\Webhook\Exceptions\CouldNotSendNotification

--- a/src/WebhookChannel.php
+++ b/src/WebhookChannel.php
@@ -38,7 +38,7 @@ class WebhookChannel
 
         $webhookData = $notification->toWebhook($notifiable)->toArray();
 
-        $response = $this->client->post($url, [
+        $response = $this->client->request($webhookData['method'], $url, [
             'query' => Arr::get($webhookData, 'query'),
             'body' => json_encode(Arr::get($webhookData, 'data')),
             'verify' => Arr::get($webhookData, 'verify'),

--- a/src/WebhookMessage.php
+++ b/src/WebhookMessage.php
@@ -40,6 +40,13 @@ class WebhookMessage
     protected $verify = false;
 
     /**
+     * The Guzzle method option.
+     *
+     * @var string
+     */
+    protected $method = 'POST';
+
+    /**
      * @param mixed $data
      *
      * @return static
@@ -81,6 +88,21 @@ class WebhookMessage
     public function data($data)
     {
         $this->data = $data;
+
+        return $this;
+    }
+
+
+    /**
+     * Set the Webhook method
+     *
+     * @param mixed $data
+     *
+     * @return $this
+     */
+    public function method($method)
+    {
+        $this->method = $method;
 
         return $this;
     }
@@ -136,6 +158,7 @@ class WebhookMessage
             'data' => $this->data,
             'headers' => $this->headers,
             'verify' => $this->verify,
+            'method' => $this->method,
         ];
     }
 }

--- a/src/WebhookMessage.php
+++ b/src/WebhookMessage.php
@@ -47,7 +47,7 @@ class WebhookMessage
     protected $method = 'POST';
 
     /**
-     * @param mixed $data
+     * @param  mixed  $data
      *
      * @return static
      */
@@ -57,7 +57,7 @@ class WebhookMessage
     }
 
     /**
-     * @param mixed $data
+     * @param  mixed  $data
      */
     public function __construct($data = '')
     {
@@ -67,7 +67,7 @@ class WebhookMessage
     /**
      * Set the Webhook parameters to be URL encoded.
      *
-     * @param mixed $query
+     * @param  mixed  $query
      *
      * @return $this
      */
@@ -81,7 +81,7 @@ class WebhookMessage
     /**
      * Set the Webhook data to be JSON encoded.
      *
-     * @param mixed $data
+     * @param  mixed  $data
      *
      * @return $this
      */
@@ -96,7 +96,7 @@ class WebhookMessage
     /**
      * Set the Webhook method
      *
-     * @param mixed $data
+     * @param  mixed  $data
      *
      * @return $this
      */
@@ -110,8 +110,8 @@ class WebhookMessage
     /**
      * Add a Webhook request custom header.
      *
-     * @param string $name
-     * @param string $value
+     * @param  string  $name
+     * @param  string  $value
      *
      * @return $this
      */
@@ -125,7 +125,7 @@ class WebhookMessage
     /**
      * Set the Webhook request UserAgent.
      *
-     * @param string $userAgent
+     * @param  string  $userAgent
      *
      * @return $this
      */

--- a/src/WebhookMessage.php
+++ b/src/WebhookMessage.php
@@ -48,7 +48,6 @@ class WebhookMessage
 
     /**
      * @param  mixed  $data
-     *
      * @return static
      */
     public static function create($data = '')
@@ -68,7 +67,6 @@ class WebhookMessage
      * Set the Webhook parameters to be URL encoded.
      *
      * @param  mixed  $query
-     *
      * @return $this
      */
     public function query($query)
@@ -82,7 +80,6 @@ class WebhookMessage
      * Set the Webhook data to be JSON encoded.
      *
      * @param  mixed  $data
-     *
      * @return $this
      */
     public function data($data)
@@ -94,10 +91,9 @@ class WebhookMessage
 
 
     /**
-     * Set the Webhook method
+     * Set the Webhook method.
      *
      * @param  mixed  $data
-     *
      * @return $this
      */
     public function method($method)
@@ -112,7 +108,6 @@ class WebhookMessage
      *
      * @param  string  $name
      * @param  string  $value
-     *
      * @return $this
      */
     public function header($name, $value)
@@ -126,7 +121,6 @@ class WebhookMessage
      * Set the Webhook request UserAgent.
      *
      * @param  string  $userAgent
-     *
      * @return $this
      */
     public function userAgent($userAgent)
@@ -138,7 +132,6 @@ class WebhookMessage
 
     /**
      * Indicate that the request should be verified.
-     *
      * @return $this
      */
     public function verify($value = true)

--- a/src/WebhookMessage.php
+++ b/src/WebhookMessage.php
@@ -89,7 +89,6 @@ class WebhookMessage
         return $this;
     }
 
-
     /**
      * Set the Webhook method.
      *
@@ -132,6 +131,7 @@ class WebhookMessage
 
     /**
      * Indicate that the request should be verified.
+     *
      * @return $this
      */
     public function verify($value = true)

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -18,9 +18,10 @@ class ChannelTest extends TestCase
     {
         $response = new Response(200);
         $client = Mockery::mock(Client::class);
-        $client->shouldReceive('post')
+        $client->shouldReceive('request')
             ->once()
             ->with(
+                'POST',
                 'https://notifiable-webhook-url.com',
                 [
                     'query' => null,
@@ -42,9 +43,10 @@ class ChannelTest extends TestCase
     {
         $response = new Response(201);
         $client = Mockery::mock(Client::class);
-        $client->shouldReceive('post')
+        $client->shouldReceive('request')
             ->once()
             ->with(
+                'POST',
                 'https://notifiable-webhook-url.com',
                 [
                     'query' => null,
@@ -66,9 +68,10 @@ class ChannelTest extends TestCase
     {
         $response = new Response();
         $client = Mockery::mock(Client::class);
-        $client->shouldReceive('post')
+        $client->shouldReceive('request')
             ->once()
             ->with(
+                'POST',
                 'https://notifiable-webhook-url.com',
                 [
                     'query' => [
@@ -100,7 +103,7 @@ class ChannelTest extends TestCase
         $this->expectExceptionCode(500);
 
         $client = Mockery::mock(Client::class);
-        $client->shouldReceive('post')
+        $client->shouldReceive('request')
             ->once()
             ->andReturn($response);
         $channel = new WebhookChannel($client);

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -67,4 +67,12 @@ class MessageTest extends TestCase
         $this->message->verify();
         $this->assertEquals(true, Arr::get($this->message->toArray(), 'verify'));
     }
+
+    /** @test */
+    public function it_can_set_the_method_to_get()
+    {
+        $webhookMessage = new WebhookMessage();
+        $webhookMessage->method('GET');
+        $this->assertEquals('GET', $webhookMessage->toArray()['method']);
+    }
 }


### PR DESCRIPTION
This pull request introduces a new `method` function in the `WebhookMessage` class. This function allows setting the HTTP method for the webhook request. The HTTP method can be any valid method such as 'GET', 'POST', 'PUT', 'DELETE', etc.

The `method` function enhances the flexibility of the `WebhookMessage` class by allowing the user to specify the HTTP method used when sending the webhook request. This is particularly useful when interacting with APIs that require specific HTTP methods for certain endpoints.

Here is a brief overview of the changes:

- Added a new `method` function in the `WebhookMessage` class.
- The `method` function accepts a string parameter representing the HTTP method.
- The HTTP method is stored in the `method` property of the `WebhookMessage` class.

This change has been fully tested to ensure it works as expected and maintains the existing functionality of the `WebhookMessage` class. The corresponding unit tests have also been added to verify the correct behavior of the new function.