### PR TITLE
Fix exception deprecation notice

### DIFF
--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -9,21 +9,19 @@ class CouldNotSendNotification extends \Exception
     private $response;
 
     /**
-     * @param Response $response
-     * @param string $message
-     * @param int|null $code
+     * @param  Response  $response
+     * @param  string  $message
+     * @param  int|null  $code
      */
-    public function __construct(Response $response, string $message, int $code = null)
+    public function __construct(Response $response, string $message, ?int $code = null)
     {
-        $this->response = $response;
-        $this->message = $message;
-        $this->code = $code ?? $response->getStatusCode();
+        parent::__construct($message, $code ?? $response->getStatusCode());
 
-        parent::__construct($message, $code);
+        $this->response = $response;
     }
 
     /**
-     * @param Response $response
+     * @param  Response  $response
      * @return self
      */
     public static function serviceRespondedWithAnError(Response $response)

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -13,6 +13,13 @@ use Orchestra\Testbench\TestCase;
 
 class ChannelTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutDeprecationHandling();
+    }
+
     /** @test */
     public function it_can_send_a_notification()
     {

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -14,6 +14,8 @@ class MessageTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        $this->withoutDeprecationHandling();
         $this->message = new WebhookMessage();
     }
 


### PR DESCRIPTION
Fixed the following deprecation notice:

"Exception::__construct(): Passing null to parameter #2 ($code) of type int is deprecated"